### PR TITLE
Move deprecated methods to their own section.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for WebService-Pushover
 
+       Moved deprecated methods out of main interface documentation.
+
 0.2.0  Fri Jan 10 10:35:18 2014
        Fix for non-creator user key issue (thanks Chisel Wright!)
        Added sounds() and bumped minor version.

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     WebService::Pushover - interface to Pushover API
 
 VERSION
-    This document describes WebService::Pushover version 0.1.2.
+    This document describes WebService::Pushover version 0.2.0.
 
 SYNOPSIS
         use WebService::Pushover;
@@ -88,10 +88,6 @@ INTERFACE
             Select a sound to be associated with this notification. Check
             the Pushover API documentation for valid values.
 
-    push(*%params*)
-        *push()* is a DEPRECATED alias for *message()*. It will be removed
-        in a future release, but remains for backwards compatibility.
-
     user(*%params*)
         *user()* sends an application token and a user token to Pushover and
         returns a scalar reference representation of the validity of those
@@ -109,10 +105,6 @@ INTERFACE
             The Pushover device name; if not supplied, the message will go
             to all devices registered to the user token.
 
-    tokens(*%params*)
-        *tokens()* is a DEPRECATED alias for *user()*. It will be removed in
-        a future release, but remains for backwards compatibility.
-
     receipt(*%params*)
         *receipt()* sends an application token and a receipt token to
         Pushover and returns a scalar reference representation of the
@@ -126,6 +118,26 @@ INTERFACE
         receipt REQUIRED
             The Pushover receipt token, obtained by parsing the output
             returned after sending a message with emergency priority.
+
+    sounds(*%params*)
+        *sounds()* sends an application token to Pushover and returns a hash
+        reference listing the available sounds (suitable for passing to the
+        *sound* parameter of the *message()*. The following are valid
+        parameters:
+
+        token REQUIRED
+            The Pushover application token, obtained by registering at
+            <http://pushover.net/apps>.
+
+  DEPRECATED METHODS
+    The following methods are depreated, and will be removed in a future
+    release. They remain for now to provide backwards compatibility.
+
+    push(*%params*)
+        *push()* is a DEPRECATED alias for *message()*.
+
+    tokens(*%params*)
+        *tokens()* is a DEPRECATED alias for *user()*.
 
 DIAGNOSTICS
     Inspect the value returned by any method, which will be a Perl data
@@ -180,4 +192,3 @@ DISCLAIMER OF WARRANTY
     SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
     DAMAGES.
 
-https://travis-ci.org/hakamadare/webservice-pushover

--- a/lib/WebService/Pushover.pm
+++ b/lib/WebService/Pushover.pm
@@ -405,10 +405,6 @@ documentation for valid values.
 
 =back
 
-=item push(I<%params>)
-
-I<push()> is a B<DEPRECATED> alias for I<message()>.  It will be removed in a future release, but remains for backwards compatibility.
-
 =item user(I<%params>)
 
 I<user()> sends an application token and a user token to Pushover and
@@ -431,10 +427,6 @@ The Pushover device name; if not supplied, the message will go to all devices
 registered to the user token.
 
 =back
-
-=item tokens(I<%params>)
-
-I<tokens()> is a B<DEPRECATED> alias for I<user()>.  It will be removed in a future release, but remains for backwards compatibility.
 
 =item receipt(I<%params>)
 
@@ -468,6 +460,23 @@ the I<message()>.  The following are valid parameters:
 The Pushover application token, obtained by registering at L<http://pushover.net/apps>.
 
 =back
+
+=back
+
+=head2 DEPRECATED METHODS
+
+The following methods are depreated, and will be removed in a future
+release. They remain for now to provide backwards compatibility.
+
+=over
+
+=item push(I<%params>)
+
+I<push()> is a B<DEPRECATED> alias for I<message()>.
+
+=item tokens(I<%params>)
+
+I<tokens()> is a B<DEPRECATED> alias for I<user()>.
 
 =back
 


### PR DESCRIPTION
They were cluttering up the main interface documentation, so now
they've been moved out of the way.
