### PR TITLE
Made test dependencies more lenient

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -29,9 +29,6 @@ my $builder = Module::Build->new(
         'Test::Deep'          => 0,
         'Test::Fake::HTTPD'   => 0,
         'Test::More'          => 0,
-        'Test::Perl::Critic'  => 0,
-        'Test::Pod::Coverage' => 1.04,
-        'Test::Pod'           => 1.14,
     },
     meta_merge => {
         resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,6 @@ WriteMakefile
                    'Net::HTTP::Spore' => 0,
                    'DateTime' => 0,
                    'URI' => 0,
-                   'Test::Pod::Coverage' => '1.04',
                    'version' => 0,
                    'Moo' => 0,
                    'File::Spec' => 0,
@@ -22,8 +21,6 @@ WriteMakefile
                    'JSON'                => 0,
                    'Test::Deep'          => 0,
                    'Test::Fake::HTTP'    => 0,
-                   'Test::Pod' => '1.14',
-                   'Test::Perl::Critic' => 0,
                    'Test::More' => 0,
                    'Params::Validate' => 0
                  }

--- a/lib/WebService/Pushover.pm
+++ b/lib/WebService/Pushover.pm
@@ -1,6 +1,7 @@
 package WebService::Pushover;
+use strict;
+
 use Moo;
-no strict 'refs';
 
 binmode STDOUT, ":encoding(UTF-8)";
 

--- a/t/critic.t
+++ b/t/critic.t
@@ -1,0 +1,7 @@
+#!perl -T
+
+use Test::More;
+
+eval "use Test::Perl::Critic";
+plan skip_all => "Test::Perl::Critic required for testing Perl::Critic" if $@;
+all_critic_ok(qw/bin lib/);


### PR DESCRIPTION
* Added a Perl::Critic test, only run if Test::Perl::Critic
  is installed.
* Ensured the pod + pod coverage tests only run if Test::Pod
  and Test::Pod::Coverage are installed.
* Removed dependencies for Test::Pod, Test::Pod::Coverage, and
  Test::Perl::Critic, since testing no longer explicitly requires
  them.

fixes #8