### PR TITLE
Match Build.PL Perl use version to configured value

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,4 +1,4 @@
-use 5.006;
+use 5.008;
 use strict;
 use warnings;
 use Module::Build::Pluggable qw(


### PR DESCRIPTION
The explicitly configured minimum Perl version in the Build.PL is set to
5.8, however the Build.PL script itself had a minimum version set to
5.6.  This change makes the minimum required Perl versions consistent
with one another.

This PR is sumbitted in the hope that it is useful.  If there is anything I should improve or change, please just let me know and I'll update and resubmit the PR.