### PR TITLE
Avoid OTRS Perl::Critic policies

### DIFF
--- a/t/critic.t
+++ b/t/critic.t
@@ -3,8 +3,10 @@ use strict;
 use warnings;
 
 use Test::More;
+use File::Spec;
 
 eval "use Test::Perl::Critic";
 plan skip_all => "Test::Perl::Critic required for testing Perl::Critic" if $@;
-Test::Perl::Critic->import(-theme => 'core', -severity => 5);
+my $rcfile = File::Spec->catfile( 't', 'perlcriticrc' );
+Test::Perl::Critic->import( -profile => $rcfile );
 all_critic_ok(qw/bin lib/);

--- a/t/critic.t
+++ b/t/critic.t
@@ -6,4 +6,5 @@ use Test::More;
 
 eval "use Test::Perl::Critic";
 plan skip_all => "Test::Perl::Critic required for testing Perl::Critic" if $@;
+Test::Perl::Critic->import(-theme => 'core', -severity => 5);
 all_critic_ok(qw/bin lib/);

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -1,0 +1,2 @@
+theme    = core
+severity = 5


### PR DESCRIPTION
This PR specifies the Perl::Critic theme and severity level explicitly so as to avoid other Perl::Critic policies being used unnecessarily in the `critic.t` tests.  The solution implemented here is basically that described by @olof in #14 and solves the problem of the extra, unwanted Perl::Critic violations (which were only those for OTRS anyway). Two solutions are implemented here: a simple, quick fix of the issue by explicitly specifying the Perl::Critic settings in the test file, and a more extensible solution using a `perlcriticrc` file.  I've put these in separate commits so that you can cherry pick them if so desired.

This PR is submitted in the hope that it is useful.  If you need any changes to it, please just let me know and I'll updated it and resubmit.