### PR TITLE
Fix Perl::Critic violations in tests

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -32,6 +32,7 @@ my $builder = Module::Build::Pluggable->new(
         'Test::Deep'          => 0,
         'Test::Fake::HTTPD'   => 0,
         'Test::More'          => 0,
+        'Class::Load'         => 0,
     },
     meta_merge => {
         resources => {

--- a/t/critic.t
+++ b/t/critic.t
@@ -3,7 +3,8 @@ use strict;
 use warnings;
 
 use Test::More;
+use Class::Load qw(try_load_class);
 
-eval "use Test::Perl::Critic";
-plan skip_all => "Test::Perl::Critic required for testing Perl::Critic" if $@;
-all_critic_ok(qw/bin lib/);
+try_load_class("Test::Perl::Critic")
+    or plan skip_all => "Test::Perl::Critic required for testing Perl::Critic";
+Test::Perl::Critic::all_critic_ok(qw/bin lib/);

--- a/t/critic.t
+++ b/t/critic.t
@@ -7,4 +7,4 @@ use Class::Load qw(try_load_class);
 
 try_load_class("Test::Perl::Critic")
     or plan skip_all => "Test::Perl::Critic required for testing Perl::Critic";
-Test::Perl::Critic::all_critic_ok(qw/bin lib/);
+Test::Perl::Critic::all_critic_ok(qw/bin lib t/);

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -4,6 +4,9 @@ use warnings;
 use strict;
 
 use Test::More;
-eval "use Test::Pod::Coverage 1.04";
-plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage" if $@;
-all_pod_coverage_ok();
+use Class::Load qw(try_load_class);
+
+my $min_tpc = 1.04;
+try_load_class('Test::Pod::Coverage', {-version => $min_tpc})
+    or plan skip_all => "Test::Pod::Coverage $min_tpc required for testing POD coverage";
+Test::Pod::Coverage::all_pod_coverage_ok();

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.04";
 plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage" if $@;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod 1.14";
 plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,6 +4,9 @@ use warnings;
 use strict;
 
 use Test::More;
-eval "use Test::Pod 1.14";
-plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
-all_pod_files_ok();
+use Class::Load qw(try_load_class);
+my $min_tp = 1.14;
+
+try_load_class('Test::Pod', {-version => $min_tp})
+    or plan skip_all => "Test::Pod $min_tp required for testing POD";
+Test::Pod::all_pod_files_ok();


### PR DESCRIPTION
The test files were not adhering to the Perl::Critic standards that the rest of the code is kept to (via the `critic.t` tests).  These changes bring the test files up to the same best practices standard and allow the test files to also be checked for Perl::Critic violations.

This PR is submitted in the hope that it is useful.  If it can be improved upon in any way, please just let me know and I'll update and resubmit as necessary.