### PR TITLE
Update copyright year to current release

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -211,7 +211,7 @@ Steve Huff  `<shuff@cpan.org>`
 
 # LICENCE AND COPYRIGHT
 
-Copyright (c) 2012, Steve Huff `<shuff@cpan.org>`. All rights reserved.
+Copyright (c) 2012-2015, Steve Huff `<shuff@cpan.org>`. All rights reserved.
 
 This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See [perlartistic](https://metacpan.org/pod/perlartistic).

--- a/lib/WebService/Pushover.pm
+++ b/lib/WebService/Pushover.pm
@@ -571,7 +571,7 @@ Steve Huff  C<< <shuff@cpan.org> >>
 
 =head1 LICENCE AND COPYRIGHT
 
-Copyright (c) 2012, Steve Huff C<< <shuff@cpan.org> >>. All rights reserved.
+Copyright (c) 2012-2015, Steve Huff C<< <shuff@cpan.org> >>. All rights reserved.
 
 This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See L<perlartistic>.


### PR DESCRIPTION
Since the current release year is 2015, it seemed sensible to update the copyright information in the code to include this date.